### PR TITLE
feat: General Preferences panel

### DIFF
--- a/Sources/SnapPathCore/ClipboardService.swift
+++ b/Sources/SnapPathCore/ClipboardService.swift
@@ -9,16 +9,24 @@ public class ClipboardService {
         pasteboard.setString(string, forType: .string)
     }
 
-    /// Formats a single file path for clipboard output.
-    /// Currently returns the plain path. Will be wired to PathFormat preference in issue #6.
-    public func formatPath(_ path: String) -> String {
-        return path
+    /// Formats a single file path for clipboard output according to the given format.
+    public func formatPath(_ path: String, format: PathFormat = .plain) -> String {
+        switch format {
+        case .plain:
+            return path
+        case .quoted:
+            return "\"\(path)\""
+        case .markdown:
+            let name = (path as NSString).lastPathComponent
+            let nameWithoutExt = (name as NSString).deletingPathExtension
+            return "![\(nameWithoutExt)](\(path))"
+        }
     }
 
     /// Copies multiple file paths to the clipboard, one per line,
-    /// each formatted via `formatPath(_:)`.
-    public func copyPathsToClipboard(_ paths: [String]) {
-        let formatted = paths.map { formatPath($0) }.joined(separator: "\n")
+    /// each formatted via `formatPath(_:format:)`.
+    public func copyPathsToClipboard(_ paths: [String], format: PathFormat = .plain) {
+        let formatted = paths.map { formatPath($0, format: format) }.joined(separator: "\n")
         copyToClipboard(formatted)
     }
 }

--- a/Sources/SnapPathCore/PreferencesManager.swift
+++ b/Sources/SnapPathCore/PreferencesManager.swift
@@ -1,7 +1,26 @@
 import AppKit
 
+/// Describes how file paths are formatted when copied to the clipboard.
+public enum PathFormat: String, CaseIterable {
+    case plain    = "plain"
+    case quoted   = "quoted"
+    case markdown = "markdown"
+
+    public var displayName: String {
+        switch self {
+        case .plain:    return "Plain"
+        case .quoted:   return "Quoted"
+        case .markdown: return "Markdown"
+        }
+    }
+}
+
 public class PreferencesManager {
     private static let saveDirectoryKey = "SaveDirectory"
+    private static let pathFormatKey      = "PathFormat"
+    private static let filenamePrefixKey  = "FilenamePrefix"
+    private static let autoOpenPickerKey  = "AutoOpenPicker"
+    private static let playSoundKey       = "PlayCaptureSound"
 
     private static let defaultDirectory: String = {
         NSSearchPathForDirectoriesInDomains(
@@ -26,6 +45,36 @@ public class PreferencesManager {
             return "~" + full.dropFirst(home.count)
         }
         return full
+    }
+
+    public var pathFormat: PathFormat {
+        get {
+            let raw = UserDefaults.standard.string(forKey: Self.pathFormatKey) ?? PathFormat.plain.rawValue
+            return PathFormat(rawValue: raw) ?? .plain
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: Self.pathFormatKey) }
+    }
+
+    public var filenamePrefix: String {
+        get {
+            let v = UserDefaults.standard.string(forKey: Self.filenamePrefixKey) ?? "Screenshot_"
+            let trimmed = v.trimmingCharacters(in: .whitespaces)
+            return trimmed.isEmpty ? "Screenshot_" : trimmed
+        }
+        set {
+            let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+            UserDefaults.standard.set(trimmed.isEmpty ? "Screenshot_" : trimmed, forKey: Self.filenamePrefixKey)
+        }
+    }
+
+    public var autoOpenPicker: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.autoOpenPickerKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.autoOpenPickerKey) }
+    }
+
+    public var playSound: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.playSoundKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.playSoundKey) }
     }
 
     public func promptForSaveDirectory(completion: @escaping () -> Void) {

--- a/Sources/SnapPathCore/PreferencesWindowController.swift
+++ b/Sources/SnapPathCore/PreferencesWindowController.swift
@@ -1,0 +1,145 @@
+import AppKit
+
+/// Window controller for the General Preferences panel.
+/// Built programmatically (no XIBs). Presents a single-page layout
+/// that will be promoted to a tabbed interface when additional panes
+/// (e.g., Shortcuts) are added.
+public class PreferencesWindowController: NSWindowController {
+    private let preferences: PreferencesManager
+
+    public init(preferences: PreferencesManager) {
+        self.preferences = preferences
+        let vc = PreferencesViewController(preferences: preferences)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 280),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "SnapPath Preferences"
+        window.contentViewController = vc
+        window.center()
+        window.isReleasedWhenClosed = false
+        super.init(window: window)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not implemented") }
+}
+
+// MARK: - PreferencesViewController
+
+private class PreferencesViewController: NSViewController {
+    private let preferences: PreferencesManager
+
+    init(preferences: PreferencesManager) {
+        self.preferences = preferences
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not implemented") }
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 280))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        buildUI()
+    }
+
+    // MARK: - UI Construction
+
+    private func buildUI() {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+        ])
+
+        // --- Path Format (#6) ---
+        stack.addArrangedSubview(sectionLabel("Clipboard"))
+        let formatRow = NSStackView()
+        formatRow.orientation = .horizontal
+        formatRow.spacing = 8
+        let formatLabel = NSTextField(labelWithString: "Path format:")
+        let seg = NSSegmentedControl(
+            labels: PathFormat.allCases.map { $0.displayName },
+            trackingMode: .selectOne,
+            target: self,
+            action: #selector(pathFormatChanged(_:))
+        )
+        seg.selectedSegment = PathFormat.allCases.firstIndex(of: preferences.pathFormat) ?? 0
+        formatRow.addArrangedSubview(formatLabel)
+        formatRow.addArrangedSubview(seg)
+        stack.addArrangedSubview(formatRow)
+
+        // --- Filename Prefix (#7) ---
+        stack.addArrangedSubview(sectionLabel("Files"))
+        let prefixRow = NSStackView()
+        prefixRow.orientation = .horizontal
+        prefixRow.spacing = 8
+        let prefixLabel = NSTextField(labelWithString: "Filename prefix:")
+        let prefixField = NSTextField()
+        prefixField.stringValue = preferences.filenamePrefix
+        prefixField.placeholderString = "Screenshot_"
+        prefixField.widthAnchor.constraint(equalToConstant: 160).isActive = true
+        prefixField.target = self
+        prefixField.action = #selector(prefixChanged(_:))
+        prefixRow.addArrangedSubview(prefixLabel)
+        prefixRow.addArrangedSubview(prefixField)
+        stack.addArrangedSubview(prefixRow)
+
+        // --- Capture Sound (#9) ---
+        stack.addArrangedSubview(sectionLabel("Capture"))
+        let soundCheck = NSButton(
+            checkboxWithTitle: "Play capture sound",
+            target: self,
+            action: #selector(soundToggled(_:))
+        )
+        soundCheck.state = preferences.playSound ? .on : .off
+        stack.addArrangedSubview(soundCheck)
+
+        // --- Auto-open File Picker (#8) ---
+        stack.addArrangedSubview(sectionLabel("Workflow"))
+        let autoOpenCheck = NSButton(
+            checkboxWithTitle: "Auto-open file picker after capture",
+            target: self,
+            action: #selector(autoOpenToggled(_:))
+        )
+        autoOpenCheck.state = preferences.autoOpenPicker ? .on : .off
+        stack.addArrangedSubview(autoOpenCheck)
+    }
+
+    /// Creates a styled section header label.
+    private func sectionLabel(_ text: String) -> NSTextField {
+        let label = NSTextField(labelWithString: text.uppercased())
+        label.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+        label.textColor = .secondaryLabelColor
+        return label
+    }
+
+    // MARK: - Actions
+
+    @objc private func pathFormatChanged(_ sender: NSSegmentedControl) {
+        let format = PathFormat.allCases[sender.selectedSegment]
+        preferences.pathFormat = format
+    }
+
+    @objc private func prefixChanged(_ sender: NSTextField) {
+        preferences.filenamePrefix = sender.stringValue
+    }
+
+    @objc private func soundToggled(_ sender: NSButton) {
+        preferences.playSound = sender.state == .on
+    }
+
+    @objc private func autoOpenToggled(_ sender: NSButton) {
+        preferences.autoOpenPicker = sender.state == .on
+    }
+}

--- a/Sources/SnapPathCore/ScreenCaptureService.swift
+++ b/Sources/SnapPathCore/ScreenCaptureService.swift
@@ -10,8 +10,13 @@ public class ScreenCaptureService {
     public init() {}
 
     /// Performs a screenshot and returns the saved file path, or nil if cancelled/failed.
-    public func capture(mode: CaptureMode, directory: String) -> String? {
-        let filePath = generateFilePath(in: directory)
+    /// - Parameters:
+    ///   - mode: The capture mode (full screen, window, or selection).
+    ///   - directory: The directory in which to save the screenshot.
+    ///   - prefix: The filename prefix (default: "Screenshot_").
+    ///   - muted: When true, passes `-x` to suppress the capture sound (default: true).
+    public func capture(mode: CaptureMode, directory: String, prefix: String = "Screenshot_", muted: Bool = true) -> String? {
+        let filePath = generateFilePath(in: directory, prefix: prefix)
 
         // Ensure save directory exists
         let fm = FileManager.default
@@ -24,7 +29,7 @@ public class ScreenCaptureService {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
-        process.arguments = buildArguments(mode: mode, filePath: filePath)
+        process.arguments = buildArguments(mode: mode, filePath: filePath, muted: muted)
 
         do {
             try process.run()
@@ -42,8 +47,9 @@ public class ScreenCaptureService {
         return nil
     }
 
-    private func buildArguments(mode: CaptureMode, filePath: String) -> [String] {
-        var args = ["-x"] // No capture sound
+    private func buildArguments(mode: CaptureMode, filePath: String, muted: Bool) -> [String] {
+        var args: [String] = []
+        if muted { args.append("-x") }
         switch mode {
         case .fullScreen:
             break
@@ -56,17 +62,18 @@ public class ScreenCaptureService {
         return args
     }
 
-    func generateFilePath(in directory: String) -> String {
+    func generateFilePath(in directory: String, prefix: String = "Screenshot_") -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
         let timestamp = formatter.string(from: Date())
-        var filename = "Screenshot_\(timestamp).png"
+        var filename = "\(prefix)\(timestamp).png"
         var fullPath = (directory as NSString).appendingPathComponent(filename)
 
         // Handle same-second collisions
         var counter = 2
         while FileManager.default.fileExists(atPath: fullPath) {
-            filename = "Screenshot_\(timestamp)-\(counter).png"
+            filename = "\(prefix)\(timestamp)-\(counter).png"
             fullPath = (directory as NSString).appendingPathComponent(filename)
             counter += 1
         }

--- a/Sources/SnapPathCore/StatusBarController.swift
+++ b/Sources/SnapPathCore/StatusBarController.swift
@@ -10,6 +10,7 @@ public class StatusBarController: NSObject, NSMenuDelegate {
     private var recentSubMenu: NSMenu?
     private var lastCapturedPath: String?
     private weak var showLastCaptureItem: NSMenuItem?
+    private var preferencesWindowController: PreferencesWindowController?
 
     public override init() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
@@ -85,7 +86,7 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         let changeDir = NSMenuItem(
             title: "Change Save Directory\u{2026}",
             action: #selector(changeSaveDirectory),
-            keyEquivalent: ","
+            keyEquivalent: ""
         )
         changeDir.target = self
         menu.addItem(changeDir)
@@ -107,6 +108,16 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         showLast.isEnabled = lastCapturedPath != nil
         menu.addItem(showLast)
         showLastCaptureItem = showLast
+
+        menu.addItem(NSMenuItem.separator())
+
+        let prefsItem = NSMenuItem(
+            title: "Preferences\u{2026}",
+            action: #selector(openPreferences),
+            keyEquivalent: ","
+        )
+        prefsItem.target = self
+        menu.addItem(prefsItem)
 
         menu.addItem(NSMenuItem.separator())
 
@@ -176,7 +187,8 @@ public class StatusBarController: NSObject, NSMenuDelegate {
 
     @objc private func copyRecentPath(_ sender: NSMenuItem) {
         guard let path = sender.representedObject as? String else { return }
-        clipboard.copyToClipboard(path)
+        let formatted = clipboard.formatPath(path, format: preferences.pathFormat)
+        clipboard.copyToClipboard(formatted)
         showNotification(path: path)
     }
 
@@ -196,17 +208,31 @@ public class StatusBarController: NSObject, NSMenuDelegate {
 
     private func performCapture(mode: ScreenCaptureService.CaptureMode) {
         let saveDir = preferences.saveDirectory
+        let prefix = preferences.filenamePrefix
+        let muted = !preferences.playSound
+        let format = preferences.pathFormat
+        let shouldAutoOpen = preferences.autoOpenPicker
 
         // Run capture on background thread to avoid blocking the main thread
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let filePath = self?.captureService.capture(mode: mode, directory: saveDir)
+            let filePath = self?.captureService.capture(
+                mode: mode,
+                directory: saveDir,
+                prefix: prefix,
+                muted: muted
+            )
 
             DispatchQueue.main.async {
                 guard let self = self, let path = filePath else { return }
-                self.clipboard.copyToClipboard(path)
+                let formatted = self.clipboard.formatPath(path, format: format)
+                self.clipboard.copyToClipboard(formatted)
                 self.lastCapturedPath = path
                 self.showLastCaptureItem?.isEnabled = true
                 self.showNotification(path: path)
+
+                if shouldAutoOpen {
+                    self.copyPaths()
+                }
             }
         }
     }
@@ -269,7 +295,7 @@ public class StatusBarController: NSObject, NSMenuDelegate {
             DispatchQueue.main.async {
                 guard let self = self, response == .OK, !panel.urls.isEmpty else { return }
                 let paths = panel.urls.map { $0.path }
-                self.clipboard.copyPathsToClipboard(paths)
+                self.clipboard.copyPathsToClipboard(paths, format: self.preferences.pathFormat)
                 let count = paths.count
                 if count == 1 {
                     self.showNotification(path: paths[0])
@@ -296,6 +322,15 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         preferences.promptForSaveDirectory { [weak self] in
             self?.setupMenu()
         }
+    }
+
+    @objc private func openPreferences() {
+        if preferencesWindowController == nil {
+            preferencesWindowController = PreferencesWindowController(preferences: preferences)
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        preferencesWindowController?.showWindow(nil)
+        preferencesWindowController?.window?.makeKeyAndOrderFront(nil)
     }
 
     @objc private func quitApp() {

--- a/Tests/SnapPathTests/SnapPathTests.swift
+++ b/Tests/SnapPathTests/SnapPathTests.swift
@@ -73,6 +73,63 @@ final class SnapPathTests: XCTestCase {
         XCTAssertEqual(clipboard.formatPath(path), path)
     }
 
+    func testFormatPathQuoted() {
+        let clipboard = ClipboardService()
+        let path = "/Users/test/Pictures/Screenshot_2026-03-13.png"
+        XCTAssertEqual(clipboard.formatPath(path, format: .quoted), "\"\(path)\"")
+    }
+
+    func testFormatPathMarkdown() {
+        let clipboard = ClipboardService()
+        let path = "/Users/test/Pictures/Screenshot_2026-03-13.png"
+        let expected = "![Screenshot_2026-03-13](\(path))"
+        XCTAssertEqual(clipboard.formatPath(path, format: .markdown), expected)
+    }
+
+    // MARK: - ScreenCaptureService (prefix)
+
+    func testFilePathUsesCustomPrefix() {
+        let service = ScreenCaptureService()
+        let path = service.generateFilePath(in: "/tmp", prefix: "Snap_")
+        XCTAssertTrue(path.hasPrefix("/tmp/Snap_"), "Expected custom prefix, got: \(path)")
+        XCTAssertTrue(path.hasSuffix(".png"))
+    }
+
+    // MARK: - PreferencesManager (new properties)
+
+    func testDefaultPathFormatIsPlain() {
+        let prefs = PreferencesManager()
+        // Reset to ensure default
+        UserDefaults.standard.removeObject(forKey: "PathFormat")
+        XCTAssertEqual(prefs.pathFormat, .plain)
+    }
+
+    func testDefaultFilenamePrefix() {
+        let prefs = PreferencesManager()
+        UserDefaults.standard.removeObject(forKey: "FilenamePrefix")
+        XCTAssertEqual(prefs.filenamePrefix, "Screenshot_")
+    }
+
+    func testEmptyFilenamePrefixFallsBackToDefault() {
+        let prefs = PreferencesManager()
+        prefs.filenamePrefix = "   "
+        XCTAssertEqual(prefs.filenamePrefix, "Screenshot_")
+        // Clean up
+        UserDefaults.standard.removeObject(forKey: "FilenamePrefix")
+    }
+
+    func testDefaultAutoOpenPickerIsFalse() {
+        let prefs = PreferencesManager()
+        UserDefaults.standard.removeObject(forKey: "AutoOpenPicker")
+        XCTAssertFalse(prefs.autoOpenPicker)
+    }
+
+    func testDefaultPlaySoundIsFalse() {
+        let prefs = PreferencesManager()
+        UserDefaults.standard.removeObject(forKey: "PlayCaptureSound")
+        XCTAssertFalse(prefs.playSound)
+    }
+
     func testCopyPathsToClipboardSinglePath() throws {
         try XCTSkipUnless(pasteboardIsAvailable(), "NSPasteboard unavailable in headless environment")
         let clipboard = ClipboardService()


### PR DESCRIPTION
## Summary
Adds a dedicated Preferences window (cmd-,) with four settings:

- **Path format** (Plain / Quoted / Markdown) — applied to all clipboard copy operations including single capture, Copy Paths, and Recent submenu
- **Filename prefix** — configurable prefix for screenshot filenames (default: `Screenshot_`)
- **Play capture sound** — toggles the `-x` silence flag on `screencapture`
- **Auto-open file picker after capture** — automatically opens Copy Paths panel after each capture

Architecture note: `PreferencesWindowController` is a single-page General panel. It will be promoted to a tabbed layout (General + Shortcuts) when issue #5 (global keyboard shortcuts) is implemented.

## Test plan
- [ ] `make check` passes
- [ ] cmd-, opens the Preferences window
- [ ] Path format segmented control persists across app restarts
- [ ] Filename prefix field persists and is applied to new captures
- [ ] Sound toggle removes the silent flag on the next capture
- [ ] Auto-open picker toggle triggers Copy Paths after each capture

Closes #6, #7, #8, #9

🤖 Generated with Claude Code