### PR TITLE
feat: global keyboard shortcuts

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "keyboardshortcuts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
+      "state" : {
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,15 @@ import PackageDescription
 let package = Package(
     name: "SnapPath",
     platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.0.0"),
+    ],
     targets: [
         .target(
             name: "SnapPathCore",
+            dependencies: [
+                .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
+            ],
             path: "Sources/SnapPathCore"
         ),
         .executableTarget(

--- a/Sources/SnapPathCore/PreferencesWindowController.swift
+++ b/Sources/SnapPathCore/PreferencesWindowController.swift
@@ -1,23 +1,39 @@
 import AppKit
+import KeyboardShortcuts
 
-/// Window controller for the General Preferences panel.
-/// Built programmatically (no XIBs). Presents a single-page layout
-/// that will be promoted to a tabbed interface when additional panes
-/// (e.g., Shortcuts) are added.
+/// Window controller for the Preferences panel.
+/// Uses NSTabViewController with toolbar-style tabs to present
+/// General settings and Keyboard Shortcuts configuration.
 public class PreferencesWindowController: NSWindowController {
     private let preferences: PreferencesManager
 
     public init(preferences: PreferencesManager) {
         self.preferences = preferences
-        let vc = PreferencesViewController(preferences: preferences)
+
+        let tabVC = NSTabViewController()
+        tabVC.tabStyle = .toolbar
+
+        let generalVC = GeneralPreferencesViewController(preferences: preferences)
+        let generalItem = NSTabViewItem(viewController: generalVC)
+        generalItem.label = "General"
+        generalItem.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "General")
+
+        let shortcutsVC = ShortcutsViewController()
+        let shortcutsItem = NSTabViewItem(viewController: shortcutsVC)
+        shortcutsItem.label = "Shortcuts"
+        shortcutsItem.image = NSImage(systemSymbolName: "keyboard", accessibilityDescription: "Shortcuts")
+
+        tabVC.addTabViewItem(generalItem)
+        tabVC.addTabViewItem(shortcutsItem)
+
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 280),
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 320),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
         )
         window.title = "SnapPath Preferences"
-        window.contentViewController = vc
+        window.contentViewController = tabVC
         window.center()
         window.isReleasedWhenClosed = false
         super.init(window: window)
@@ -26,9 +42,11 @@ public class PreferencesWindowController: NSWindowController {
     required init?(coder: NSCoder) { fatalError("not implemented") }
 }
 
-// MARK: - PreferencesViewController
+// MARK: - GeneralPreferencesViewController
 
-private class PreferencesViewController: NSViewController {
+/// The General tab — save directory, clipboard format, filename prefix,
+/// capture sound toggle, and auto-open picker toggle.
+private class GeneralPreferencesViewController: NSViewController {
     private let preferences: PreferencesManager
 
     init(preferences: PreferencesManager) {
@@ -141,5 +159,56 @@ private class PreferencesViewController: NSViewController {
 
     @objc private func autoOpenToggled(_ sender: NSButton) {
         preferences.autoOpenPicker = sender.state == .on
+    }
+}
+
+// MARK: - ShortcutsViewController
+
+/// The Shortcuts tab — provides KeyboardShortcuts.RecorderCocoa rows for
+/// each capture mode so the user can configure global hotkeys.
+private class ShortcutsViewController: NSViewController {
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 220))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        buildUI()
+    }
+
+    private func buildUI() {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+        ])
+
+        stack.addArrangedSubview(shortcutRow(label: "Capture Full Screen:", name: .captureFullScreen))
+        stack.addArrangedSubview(shortcutRow(label: "Capture Window:", name: .captureWindow))
+        stack.addArrangedSubview(shortcutRow(label: "Capture Selection:", name: .captureSelection))
+
+        let note = NSTextField(wrappingLabelWithString: "Shortcuts work system-wide from any app.")
+        note.font = NSFont.systemFont(ofSize: 11)
+        note.textColor = .secondaryLabelColor
+        stack.addArrangedSubview(note)
+    }
+
+    /// Builds a horizontal row with a label and a shortcut recorder.
+    private func shortcutRow(label text: String, name: KeyboardShortcuts.Name) -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.spacing = 12
+        let label = NSTextField(labelWithString: text)
+        label.widthAnchor.constraint(equalToConstant: 160).isActive = true
+        let recorder = KeyboardShortcuts.RecorderCocoa(for: name)
+        row.addArrangedSubview(label)
+        row.addArrangedSubview(recorder)
+        return row
     }
 }

--- a/Sources/SnapPathCore/ShortcutNames.swift
+++ b/Sources/SnapPathCore/ShortcutNames.swift
@@ -1,0 +1,10 @@
+import KeyboardShortcuts
+
+/// Defines the configurable global keyboard shortcut names for each capture mode.
+/// These names serve as identifiers for persisting shortcut bindings via
+/// KeyboardShortcuts' built-in UserDefaults integration.
+extension KeyboardShortcuts.Name {
+    static let captureFullScreen = Self("captureFullScreen")
+    static let captureWindow     = Self("captureWindow")
+    static let captureSelection  = Self("captureSelection")
+}

--- a/Sources/SnapPathCore/StatusBarController.swift
+++ b/Sources/SnapPathCore/StatusBarController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import KeyboardShortcuts
 import UniformTypeIdentifiers
 import UserNotifications
 
@@ -17,6 +18,22 @@ public class StatusBarController: NSObject, NSMenuDelegate {
         super.init()
         setupButton()
         setupMenu()
+        registerGlobalShortcuts()
+    }
+
+    /// Registers global keyboard shortcut handlers for each capture mode.
+    /// Shortcuts use Carbon RegisterEventHotKey internally — no Accessibility
+    /// permission required. Bindings are configured by the user in Preferences.
+    private func registerGlobalShortcuts() {
+        KeyboardShortcuts.onKeyUp(for: .captureFullScreen) { [weak self] in
+            self?.performCapture(mode: .fullScreen)
+        }
+        KeyboardShortcuts.onKeyUp(for: .captureWindow) { [weak self] in
+            self?.performCapture(mode: .window)
+        }
+        KeyboardShortcuts.onKeyUp(for: .captureSelection) { [weak self] in
+            self?.performCapture(mode: .selection)
+        }
     }
 
     private func setupButton() {


### PR DESCRIPTION
## Summary
- Adds configurable global keyboard shortcuts for all three capture modes
- Shortcuts fire system-wide from any app — no Accessibility permission required (Carbon-based via `KeyboardShortcuts` package)
- Preferences window promoted to two tabs: **General** (existing settings) + **Shortcuts** (key recorder rows for each mode)
- `KeyboardShortcuts.RecorderCocoa` provides a polished native recorder matching System Settings style
- Shortcut bindings persist automatically via `KeyboardShortcuts` UserDefaults integration

## Dependencies added
- `sindresorhus/KeyboardShortcuts` ~> 2.0

## Test plan
- [ ] `make check` passes (package resolves)
- [ ] Preferences shows two tabs: General and Shortcuts
- [ ] Shortcut recorder fields appear for Full Screen, Window, Selection
- [ ] Recording a shortcut and pressing it from another app triggers the capture
- [ ] Shortcut persists after app restart
- [ ] Clearing a shortcut disables it

Closes #5

Generated with Claude Code